### PR TITLE
fix: disable mobile zoom on web page

### DIFF
--- a/site/src/app.html
+++ b/site/src/app.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="theme-color" content="#1f2937" />
     %sveltekit.head%
   </head>


### PR DESCRIPTION
## Summary

This PR fixes #105 by adding `maximum-scale=1.0` and `user-scalable=no` to the viewport `<meta>` tag in `site/src/app.html`.

## Changes

- `site/src/app.html`: Updated the `viewport` meta tag to include `maximum-scale=1.0, user-scalable=no`

## How it works

The `user-scalable=no` attribute prevents users from zooming in via double-tap or pinch gestures on mobile devices (e.g. iPhone). The `maximum-scale=1.0` reinforces this by capping the zoom level at 1x.

## Testing

Open the web app on an iPhone or Android device and verify that:
- Double-tapping no longer zooms in
- Pinching with two fingers no longer zooms in

Fixes #105